### PR TITLE
refactor: change date to 1985-10-26

### DIFF
--- a/tests/test_get_days_since_date_until_now.sh
+++ b/tests/test_get_days_since_date_until_now.sh
@@ -17,7 +17,7 @@ after_each_test() {
 }
 
 test_date_as_parameter() {
-  assert "get_days_since_date_until_now 2022-01-01"
+  assert "get_days_since_date_until_now 1985-10-26"
 }
 
 test_invalid_date_as_parameter() {


### PR DESCRIPTION
Change date becase some vagrant cloud vms are not set to use ntp
servers, so the date is wrongly set.

Signed-off-by: Thiago Canozzo Lahr <tclahr@br.ibm.com>