### PR TITLE
feat: add redirect_stderr_to_stdout property

### DIFF
--- a/tests/lib/test_parse_artifact.sh
+++ b/tests/lib/test_parse_artifact.sh
@@ -75,9 +75,10 @@ oneTimeSetUp()
     __cc_output_directory="${3:-}"
     __cc_output_file="${4:-}"
     __cc_compress_output_file="${5:-false}"
+    __cc_redirect_stderr_to_stdout="${6:-false}"
 
-    printf %b "_command_collector \"${__cc_foreach}\" \"${__cc_command}\" \"${__cc_output_directory}\" \"${__cc_output_file}\" ${__cc_compress_output_file}\n"
-    _log_msg CMD "_command_collector \"${__cc_foreach}\" \"${__cc_command}\" \"${__cc_output_directory}\" \"${__cc_output_file}\" ${__cc_compress_output_file}"
+    printf %b "_command_collector \"${__cc_foreach}\" \"${__cc_command}\" \"${__cc_output_directory}\" \"${__cc_output_file}\" ${__cc_compress_output_file} ${__cc_redirect_stderr_to_stdout}\n"
+    _log_msg CMD "_command_collector \"${__cc_foreach}\" \"${__cc_command}\" \"${__cc_output_directory}\" \"${__cc_output_file}\" ${__cc_compress_output_file} ${__cc_redirect_stderr_to_stdout}"
   }
 
   _find_based_collector() {
@@ -172,7 +173,7 @@ artifacts:
 EOF
 
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/supported_os_fail.yaml"`
-  assertNotEquals "_command_collector \"\" \"ls ${__TEST_TEMP_DIR}/uac/artifacts/supported_os_fail.yaml\" \"${__UAC_TEMP_DATA_DIR}/collected/supported_os_fail\" \"supported_os_fail.txt\" false" "${__test_actual}"
+  assertNotEquals "_command_collector \"\" \"ls ${__TEST_TEMP_DIR}/uac/artifacts/supported_os_fail.yaml\" \"${__UAC_TEMP_DATA_DIR}/collected/supported_os_fail\" \"supported_os_fail.txt\" false false" "${__test_actual}"
 }
 
 test_parse_artifact_artifacts_ignore_operating_system_true_success()
@@ -190,11 +191,11 @@ artifacts:
 EOF
 
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/supported_os_fail.yaml"`
-  assertNotEquals "_command_collector \"\" \"ls ${__TEST_TEMP_DIR}/uac/artifacts/supported_os_fail.yaml\" \"${__UAC_TEMP_DATA_DIR}/collected/supported_os_fail\" \"supported_os_fail.txt\" false" "${__test_actual}"
+  assertNotEquals "_command_collector \"\" \"ls ${__TEST_TEMP_DIR}/uac/artifacts/supported_os_fail.yaml\" \"${__UAC_TEMP_DATA_DIR}/collected/supported_os_fail\" \"supported_os_fail.txt\" false false" "${__test_actual}"
 
   __UAC_IGNORE_OPERATING_SYSTEM=true
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/supported_os_fail.yaml"`
-  assertEquals "_command_collector \"\" \"ls ${__TEST_TEMP_DIR}/uac/artifacts/supported_os_fail.yaml\" \"${__UAC_TEMP_DATA_DIR}/collected/supported_os_fail\" \"supported_os_fail.txt\" false" "${__test_actual}"
+  assertEquals "_command_collector \"\" \"ls ${__TEST_TEMP_DIR}/uac/artifacts/supported_os_fail.yaml\" \"${__UAC_TEMP_DATA_DIR}/collected/supported_os_fail\" \"supported_os_fail.txt\" false false" "${__test_actual}"
 }
 
 test_parse_artifact_artifacts_invalid_collector_fail()
@@ -345,7 +346,7 @@ artifacts:
 EOF
 
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/command_collector_single_command_success.yaml"`
-  assertEquals "_command_collector \"\" \"ps -ef\" \"${__UAC_TEMP_DATA_DIR}/collected/command_collector_single_command_success\" \"command_collector_single_command_success.txt\" false" "${__test_actual}"
+  assertEquals "_command_collector \"\" \"ps -ef\" \"${__UAC_TEMP_DATA_DIR}/collected/command_collector_single_command_success\" \"command_collector_single_command_success.txt\" false false" "${__test_actual}"
 }
 
 
@@ -370,7 +371,7 @@ EOF
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/command_collector_multiple_command_success.yaml"`
   assertEquals "_command_collector \"\" \"ps -ef
 ls -la
-lsof\" \"${__UAC_TEMP_DATA_DIR}/collected/command_collector_multiple_command_success\" \"command_collector_multiple_command_success.txt\" false" "${__test_actual}"
+lsof\" \"${__UAC_TEMP_DATA_DIR}/collected/command_collector_multiple_command_success\" \"command_collector_multiple_command_success.txt\" false false" "${__test_actual}"
 }
 
 test_parse_artifact_replace_exposed_variables_success()
@@ -393,7 +394,7 @@ artifacts:
 EOF
 
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/replace_exposed_variables_success.yaml"`
-  assertEquals "_command_collector \"\" \"ls -la 2023-01-01 1672531200 2023-01-31 1675123200 ${__UAC_MOUNT_POINT} ${__TEST_TEMP_DIR}/tmp ${__TEST_TEMP_DIR}/uac\" \"${__UAC_TEMP_DATA_DIR}/collected/replace_exposed_variables_success\" \"replace_exposed_variables_success.txt\" false" "${__test_actual}"
+  assertEquals "_command_collector \"\" \"ls -la 2023-01-01 1672531200 2023-01-31 1675123200 ${__UAC_MOUNT_POINT} ${__TEST_TEMP_DIR}/tmp ${__TEST_TEMP_DIR}/uac\" \"${__UAC_TEMP_DATA_DIR}/collected/replace_exposed_variables_success\" \"replace_exposed_variables_success.txt\" false false" "${__test_actual}"
 
   cat <<EOF >"${__TEST_TEMP_DIR}/uac/artifacts/replace_exposed_variables_success.yaml"
 version: 1.0
@@ -412,7 +413,7 @@ EOF
 
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/replace_exposed_variables_success.yaml"`
   assertEquals "_command_collector \"\" \"ls -la 2023-01-01 1672531200 2023-01-31 1675123200 ${__UAC_MOUNT_POINT} ${__TEST_TEMP_DIR}/tmp ${__TEST_TEMP_DIR}/uac
-cat /dev/null\" \"${__UAC_TEMP_DATA_DIR}/collected/replace_exposed_variables_success\" \"replace_exposed_variables_success.txt\" false" "${__test_actual}"
+cat /dev/null\" \"${__UAC_TEMP_DATA_DIR}/collected/replace_exposed_variables_success\" \"replace_exposed_variables_success.txt\" false false" "${__test_actual}"
 
   cat <<EOF >"${__TEST_TEMP_DIR}/uac/artifacts/replace_exposed_variables_success.yaml"
 version: 1.0
@@ -428,7 +429,7 @@ artifacts:
 EOF
 
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/replace_exposed_variables_success.yaml"`
-  assertEquals "_command_collector \"ls -la 2023-01-01 1672531200 2023-01-31 1675123200 ${__UAC_MOUNT_POINT} ${__TEST_TEMP_DIR}/tmp ${__TEST_TEMP_DIR}/uac\" \"ls -la\" \"${__UAC_TEMP_DATA_DIR}/collected/replace_exposed_variables_success\" \"replace_exposed_variables_success.txt\" false" "${__test_actual}"
+  assertEquals "_command_collector \"ls -la 2023-01-01 1672531200 2023-01-31 1675123200 ${__UAC_MOUNT_POINT} ${__TEST_TEMP_DIR}/tmp ${__TEST_TEMP_DIR}/uac\" \"ls -la\" \"${__UAC_TEMP_DATA_DIR}/collected/replace_exposed_variables_success\" \"replace_exposed_variables_success.txt\" false false" "${__test_actual}"
 
   cat <<EOF >"${__TEST_TEMP_DIR}/uac/artifacts/replace_exposed_variables_success.yaml"
 version: 1.0
@@ -448,7 +449,7 @@ EOF
 
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/replace_exposed_variables_success.yaml"`
   assertEquals "_command_collector \"ls -la 2023-01-01 1672531200 2023-01-31 1675123200 ${__UAC_MOUNT_POINT} ${__TEST_TEMP_DIR}/tmp ${__TEST_TEMP_DIR}/uac
-cat /dev/null\" \"ls -la\" \"${__UAC_TEMP_DATA_DIR}/collected/replace_exposed_variables_success\" \"replace_exposed_variables_success.txt\" false" "${__test_actual}"
+cat /dev/null\" \"ls -la\" \"${__UAC_TEMP_DATA_DIR}/collected/replace_exposed_variables_success\" \"replace_exposed_variables_success.txt\" false false" "${__test_actual}"
 }
 
 test_parse_artifact_command_collector_compress_output_file_success()
@@ -467,7 +468,7 @@ artifacts:
 EOF
 
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/command_collector_compress_output_file_success.yaml"`
-  assertEquals "_command_collector \"\" \"ls -la\" \"${__UAC_TEMP_DATA_DIR}/collected/command_collector_compress_output_file_success\" \"command_collector_compress_output_file_success.txt\" true" "${__test_actual}"
+  assertEquals "_command_collector \"\" \"ls -la\" \"${__UAC_TEMP_DATA_DIR}/collected/command_collector_compress_output_file_success\" \"command_collector_compress_output_file_success.txt\" true false" "${__test_actual}"
 }
 
 test_parse_artifact_command_collector_absolute_output_directory_success()
@@ -485,7 +486,7 @@ artifacts:
 EOF
 
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/command_collector_success.yaml"`
-  assertEquals "_command_collector \"\" \"ps -ef\" \"${__UAC_TEMP_DATA_DIR}/collected//command_collector_success\" \"command_collector_success.txt\" false" "${__test_actual}"
+  assertEquals "_command_collector \"\" \"ps -ef\" \"${__UAC_TEMP_DATA_DIR}/collected//command_collector_success\" \"command_collector_success.txt\" false false" "${__test_actual}"
 }
 
 test_parse_artifact_command_collector_temp_directory_output_directory_success()
@@ -504,7 +505,7 @@ artifacts:
 EOF
 
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/command_collector_temp_directory_output_directory_success.yaml"`
-  assertEquals "_command_collector \"\" \"ps -ef\" \"/${__TEST_TEMP_DIR}/tmp/command_collector_temp_directory_output_directory_success\" \"command_collector_temp_directory_output_directory_success.txt\" false" "${__test_actual}"
+  assertEquals "_command_collector \"\" \"ps -ef\" \"/${__TEST_TEMP_DIR}/tmp/command_collector_temp_directory_output_directory_success\" \"command_collector_temp_directory_output_directory_success.txt\" false false" "${__test_actual}"
 }
 
 test_parse_artifact_command_collector_empty_output_file_success()
@@ -524,7 +525,7 @@ artifacts:
 EOF
 
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/command_collector_empty_output_file_success.yaml"`
-  assertEquals "_command_collector \"\" \"ps -ef\" \"${__UAC_TEMP_DATA_DIR}/collected/command_collector_empty_output_file_success\" \"\" false" "${__test_actual}"
+  assertEquals "_command_collector \"\" \"ps -ef\" \"${__UAC_TEMP_DATA_DIR}/collected/command_collector_empty_output_file_success\" \"\" false false" "${__test_actual}"
 }
 
 test_parse_artifact_artifacts_local_condition_success()
@@ -597,9 +598,9 @@ artifacts:
 EOF
 
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/user_home_success.yaml"`
-  assertEquals "_command_collector \"\" \"ls uac /home/uac\" \"${__UAC_TEMP_DATA_DIR}/collected//home/uac_uac\" \"/home/uac_uac.txt\" false
-_command_collector \"\" \"ls john /home/john\" \"${__UAC_TEMP_DATA_DIR}/collected//home/john_john\" \"/home/john_john.txt\" false
-_command_collector \"\" \"ls daenerys /home/daenerys\" \"${__UAC_TEMP_DATA_DIR}/collected//home/daenerys_daenerys\" \"/home/daenerys_daenerys.txt\" false" "${__test_actual}"
+  assertEquals "_command_collector \"\" \"ls uac /home/uac\" \"${__UAC_TEMP_DATA_DIR}/collected//home/uac_uac\" \"/home/uac_uac.txt\" false false
+_command_collector \"\" \"ls john /home/john\" \"${__UAC_TEMP_DATA_DIR}/collected//home/john_john\" \"/home/john_john.txt\" false false
+_command_collector \"\" \"ls daenerys /home/daenerys\" \"${__UAC_TEMP_DATA_DIR}/collected//home/daenerys_daenerys\" \"/home/daenerys_daenerys.txt\" false false" "${__test_actual}"
 
   cat <<EOF >"${__TEST_TEMP_DIR}/uac/artifacts/user_home_success.yaml"
 version: 1.0
@@ -615,8 +616,8 @@ artifacts:
 EOF
 
   __test_actual=`_parse_artifact "${__TEST_TEMP_DIR}/uac/artifacts/user_home_success.yaml"`
-  assertEquals "_command_collector \"\" \"ls uac /home/uac\" \"${__UAC_TEMP_DATA_DIR}/collected//home/uac_uac\" \"/home/uac_uac.txt\" false
-_command_collector \"\" \"ls john /home/john\" \"${__UAC_TEMP_DATA_DIR}/collected//home/john_john\" \"/home/john_john.txt\" false" "${__test_actual}"
+  assertEquals "_command_collector \"\" \"ls uac /home/uac\" \"${__UAC_TEMP_DATA_DIR}/collected//home/uac_uac\" \"/home/uac_uac.txt\" false false
+_command_collector \"\" \"ls john /home/john\" \"${__UAC_TEMP_DATA_DIR}/collected//home/john_john\" \"/home/john_john.txt\" false false" "${__test_actual}"
 
   cat <<EOF >"${__TEST_TEMP_DIR}/uac/artifacts/user_home_success.yaml"
 version: 1.0

--- a/tests/lib/test_run_command.sh
+++ b/tests/lib/test_run_command.sh
@@ -46,12 +46,15 @@ test_run_command_command_success()
   assertContains "${__test_container}" "kthreadd"
 }
 
-test_run_command_command_ignore_stderr_success()
+test_run_command_command_redirect_stderr_to_stdout_success()
 {
-  assertFalse "_run_command \"__unknown_command\" false"
-  __test_container=`cat "${__TEST_TEMP_DIR}/test.log"`
+  __test_container=`_run_command "__unknown_command"`
   assertNotContains "${__test_container}" "unknown command error"
+  
+  __test_container=`_run_command "__unknown_command" true`
+  assertContains "${__test_container}" "unknown command error"
 }
+
 
 test_run_command_command_unknown_command_success()
 {

--- a/tests/lib/test_validate_artifact.sh
+++ b/tests/lib/test_validate_artifact.sh
@@ -227,6 +227,25 @@ EOF
   assertFalse "_validate_artifact \"${__TEST_TEMP_DIR}/artifacts/invalid_compress_output_file_fail.yaml\""
 }
 
+test_validate_artifact_empty_redirect_stderr_to_stdour_fail()
+{
+  cat <<EOF >"${__TEST_TEMP_DIR}/artifacts/empty_redirect_stderr_to_stdour_fail.yaml"
+version: 1.0
+artifacts:
+  -
+    description: example 1
+    supported_os: [all]
+    collector: command
+    command: ls
+    output_directory: /tmp
+    output_file: ls.txt
+    compress_output_file: true
+    redirect_stderr_to_stdout:
+EOF
+
+  assertFalse "_validate_artifact \"${__TEST_TEMP_DIR}/artifacts/empty_redirect_stderr_to_stdour_fail.yaml\""
+}
+
 test_validate_artifact_empty_global_condition_fail()
 {
   cat <<EOF >"${__TEST_TEMP_DIR}/artifacts/empty_global_condition_fail.yaml"
@@ -1844,6 +1863,28 @@ EOF
   assertFalse "_validate_artifact \"${__TEST_TEMP_DIR}/artifacts/command_collector_invalid_permissions_property_fail.yaml\""
 }
 
+test_validate_artifact_command_collector_invalid_redirect_stderr_to_stdout_fail()
+{
+  cat <<EOF >"${__TEST_TEMP_DIR}/artifacts/command_collector_invalid_redirect_stderr_to_stdout_fail.yaml"
+version: 1.0
+artifacts:
+  -
+    description: test
+    supported_os: [all]
+    collector: command
+    condition: ls /tmp
+    foreach: ls /tmp
+    command: ls
+    output_directory: /tmp
+    output_file: test.txt
+    compress_output_file: true
+    exclude_nologin_users: true
+    redirect_stderr_to_stdout: invalid
+EOF
+
+  assertFalse "_validate_artifact \"${__TEST_TEMP_DIR}/artifacts/command_collector_invalid_redirect_stderr_to_stdout_fail.yaml\""
+}
+
 test_validate_artifact_hash_collector_missing_path_property_fail()
 {
   cat <<EOF >"${__TEST_TEMP_DIR}/artifacts/hash_collector_missing_path_property_fail.yaml"
@@ -1948,6 +1989,76 @@ EOF
   assertFalse "_validate_artifact \"${__TEST_TEMP_DIR}/artifacts/hash_collector_missing_output_file_property_fail.yaml\""
 }
 
+test_validate_artifact_hash_collector_redirect_stderr_to_stdout_property_fail()
+{
+  cat <<EOF >"${__TEST_TEMP_DIR}/artifacts/hash_collector_redirect_stderr_to_stdout_property_fail.yaml"
+version: 1.0
+artifacts:
+  -
+    description: test
+    supported_os: [all]
+    collector: hash
+    path: /etc
+    output_directory: tmp
+    output_file: test.txt
+    redirect_stderr_to_stdout: true
+EOF
+
+  assertFalse "_validate_artifact \"${__TEST_TEMP_DIR}/artifacts/hash_collector_redirect_stderr_to_stdout_property_fail.yaml\""
+}
+
+test_validate_artifact_file_collector_redirect_stderr_to_stdout_property_fail()
+{
+  cat <<EOF >"${__TEST_TEMP_DIR}/artifacts/file_collector_redirect_stderr_to_stdout_property_fail.yaml"
+version: 1.0
+artifacts:
+  -
+    description: test
+    supported_os: [all]
+    collector: file
+    path: /etc
+    redirect_stderr_to_stdout: true
+EOF
+
+  assertFalse "_validate_artifact \"${__TEST_TEMP_DIR}/artifacts/file_collector_redirect_stderr_to_stdout_property_fail.yaml\""
+}
+
+test_validate_artifact_find_collector_redirect_stderr_to_stdout_property_fail()
+{
+  cat <<EOF >"${__TEST_TEMP_DIR}/artifacts/find_collector_redirect_stderr_to_stdout_property_fail.yaml"
+version: 1.0
+artifacts:
+  -
+    description: test
+    supported_os: [all]
+    collector: find
+    path: /etc
+    output_directory: tmp
+    output_file: test.txt
+    redirect_stderr_to_stdout: true
+EOF
+
+  assertFalse "_validate_artifact \"${__TEST_TEMP_DIR}/artifacts/find_collector_redirect_stderr_to_stdout_property_fail.yaml\""
+}
+
+test_validate_artifact_stat_collector_redirect_stderr_to_stdout_property_fail()
+{
+  cat <<EOF >"${__TEST_TEMP_DIR}/artifacts/stat_collector_redirect_stderr_to_stdout_property_fail.yaml"
+version: 1.0
+artifacts:
+  -
+    description: test
+    supported_os: [all]
+    collector: stat
+    path: /etc
+    output_directory: tmp
+    output_file: test.txt
+    redirect_stderr_to_stdout: true
+EOF
+
+  assertFalse "_validate_artifact \"${__TEST_TEMP_DIR}/artifacts/stat_collector_redirect_stderr_to_stdout_property_fail.yaml\""
+}
+
 test_validate_artifact_invalid_property_fail()
 {
   cat <<EOF >"${__TEST_TEMP_DIR}/artifacts/invalid_property_fail.yaml"
@@ -1973,6 +2084,7 @@ artifacts:
     output_file: test.txt
     compress_output_file: true
     exclude_nologin_users: true
+    redirect_stderr_to_stdout: true
 EOF
 
   assertTrue "_validate_artifact \"${__TEST_TEMP_DIR}/artifacts/command_collector_success.yaml\""


### PR DESCRIPTION
Added the new 'redirect_stderr_to_stdout' property, an optional feature available exclusively for the command collector. When set to true, this property redirects all error messages (stderr) to standard output (stdout), ensuring they are written to the output file.